### PR TITLE
feat: emit beforePageLoad event

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ module.exports = function domwaiter (pages, opts = {}) {
 }
 
 async function getPage (page, emitter, opts) {
+  emitter.emit('beforePageLoad', page)
+
   if (opts.json) {
     try {
       const json = await got(page.url).json()

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,8 @@ This module exports a single function `domwaiter`:
 
 The `domwaiter` function returns an event emitter which emits the following events:
 
-- `page` - Emitted as each page has been requested and parsed. Returns an object which is a shallow clone of the original `page` object you provided, but with two added properties:
+- `beforePageLoad` - Emitted with `page` object for any optional prehandling you want to do, e.g. setting up a request timer.
+- `page` - Emitted after the page has been requested and the response is parsed. Returns an object which is a shallow clone of the original `page` object you provided, but with two added properties:
   - `body`: the raw HTTP response body text
   - `$`: The body parsed into a jQuery-like [cheerio](https://ghub.io/cheerio) DOM object.
 - `error` - Emitted when an error occurs fetching a URL

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ describe('domwaiter', () => {
     expect(typeof domwaiter).toBe('function')
   })
 
-  test('emits events', (done) => {
+  test('emits `page` and `done` events', (done) => {
     const mock = nock('https://example.com')
       .get('/foo')
       .reply(200, '<html><title>Hello, foo</title></html>')
@@ -40,6 +40,25 @@ describe('domwaiter', () => {
       .on('error', (err) => {
         console.error('domwaiter error')
         console.error(err)
+      })
+  })
+
+  test('emits a `beforePageLoad` event with page object', (done) => {
+    const mock = nock('https://example.com')
+      .get('/foo')
+      .reply(200)
+
+    const pages = [
+      { url: 'https://example.com/foo' }
+    ]
+
+    const waiter = domwaiter(pages, { minTime: 10 })
+
+    waiter
+      .on('beforePageLoad', (page) => {
+        expect(mock.isDone())
+        expect(page && page.url)
+        done()
       })
   })
 


### PR DESCRIPTION
This PR adds a new `beforePageLoad` event emitter.

I'm hoping to use this feature to record response times in an app I'm working on.